### PR TITLE
Added abolitions filter in API Variable/Parameter Explorer

### DIFF
--- a/src/pages/learn/APIGeneralContent.jsx
+++ b/src/pages/learn/APIGeneralContent.jsx
@@ -399,6 +399,8 @@ export function VariableParameterExplorer(props) {
   const { metadata } = props;
   const [query, setQuery] = useState("");
   const [selectedCardData, setSelectedCardData] = useState(null);
+  const [filterByAbolition, setFilterByAbolition] = useState(false);
+
   const [page, setPage] = useState(0);
 
   const MAX_ROWS = 3;
@@ -408,16 +410,32 @@ export function VariableParameterExplorer(props) {
   if (!metadata) return null;
 
   const filterByQuery = (item) => {
-    if (!query) return true;
+    if (!query && !filterByAbolition) return true;
 
-    // Skip items with numeric or empty labels
     const label = item.label || "";
     if (!label.trim() || /^\d+$/.test(label)) return false;
 
-    return label
-      .replaceAll(" ", "")
-      .toLowerCase()
-      .includes(query.replaceAll(" ", "").toLowerCase());
+    const pythonName = item.type === "parameter" ? item.parameter : item.name;
+
+    if (filterByAbolition) {
+      // When toggle ON, exclude items starting with "gov.abolitions"
+      if (pythonName?.startsWith("gov.abolitions")) return false;
+    } else {
+      // When toggle OFF, include everything (no exclusion)
+    }
+
+    // Filter based on the query string
+    if (query) {
+      return (
+        label
+          .replaceAll(" ", "")
+          .toLowerCase()
+          .includes(query.replaceAll(" ", "").toLowerCase()) ||
+        pythonName?.toLowerCase().includes(query.toLowerCase())
+      );
+    }
+
+    return true;
   };
 
   const parameterCards = Object.values(metadata.parameters || {})
@@ -458,7 +476,20 @@ export function VariableParameterExplorer(props) {
           padding: "8px",
         }}
       />
-
+      <div style={{ marginBottom: 10 }}>
+        <label style={{ fontSize: "14px" }}>
+          <input
+            type="checkbox"
+            checked={filterByAbolition}
+            onChange={() => {
+              setFilterByAbolition((prev) => !prev);
+              setPage(0); // reset to first page
+            }}
+            style={{ marginRight: 8 }}
+          />
+          Filter abolitions
+        </label>
+      </div>
       <div
         style={{
           display: "grid",


### PR DESCRIPTION
Fixes Issue 2488 

## Description
Adds toggle-based filtering to show or hide parameters related to "abolition" in the parameter explorer.

## Changes
- Introduced filterByAbolition toggle logic.
- Filter excludes gov.abolitions* items unless toggle is enabled.

## Screenshots
<img width="1240" alt="Screenshot 2025-05-29 at 2 02 34 PM" src="https://github.com/user-attachments/assets/27fce8ae-6efc-4ac6-b63e-202c7e4fc065" />

